### PR TITLE
Make remote development icon consistent with other icons

### DIFF
--- a/themes/Atomize-color-theme.json
+++ b/themes/Atomize-color-theme.json
@@ -256,6 +256,8 @@
 		"statusBarItem.hoverBackground": "#2F333D",
 		"statusBarItem.prominentBackground": "#21252B",
 		"statusBarItem.prominentHoverBackground": "#2F333D",
+		"statusBarItem.remoteBackground": "#21252B",
+		"statusBarItem.remoteForeground": "#9DA5B4",
 
 		// Tabs
 		"tab.activeBackground": "#282C34",


### PR DESCRIPTION
The current blue icon background is inconsistent and confusing because it is not an indication of connection status.

Before
<img width="243" alt="Screen Shot 2019-06-07 at 10 12 46 AM" src="https://user-images.githubusercontent.com/44066357/59110541-5bd86800-890d-11e9-89b7-b8c9939f2ec3.png">

After
<img width="299" alt="Screen Shot 2019-06-07 at 10 16 27 AM" src="https://user-images.githubusercontent.com/44066357/59110547-60048580-890d-11e9-9d01-56d3ec4c4f66.png">
