### PR TITLE
Change color of empty editor for better contrast

### DIFF
--- a/themes/Atomize-color-theme.json
+++ b/themes/Atomize-color-theme.json
@@ -69,7 +69,7 @@
 		"editorError.foreground": "#FF6347",
 		"editorGroup.border": "#181A1F",
 		"editorGroup.dropBackground": "#4B4B4B4D",
-		"editorGroup.emptyBackground": "#21252B",
+		"editorGroup.emptyBackground": "#282C34",
 		// "editorGroup.focusedEmptyBorder": "",
 		"editorGroupHeader.noTabsBackground": "#21252B",
 		"editorGroupHeader.tabsBackground": "#21252B",


### PR DESCRIPTION
Fixes #7

Before, the empty editor was the same color as the background color of the quick picker. Since there was no contrast in between the two, it looked kinda weird.