### PR TITLE
Add note about turning off semantic highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ A detailed and accurate Atom One Dark Theme
 
 To get the icons in the screenshot above and an experience closer to Atom, check out my [Atom Icons theme](https://github.com/emroussel/atom-icons).
 
+**Note that if you want the same syntax highlighting as Atom One Dark, you will need to turn off semantic highlighting in your VS Code settings:**
+
+```json
+"editor.semanticHighlighting.enabled": false
+```
+
 ## Contribution
 
 I have mostly used this theme with JavaScript and other web technologies.


### PR DESCRIPTION
As indicated in #10, syntax highlighting changed after VS Code added semantic highlighting as the default. This note indicates how users can switch back to the original syntax highlighting (which looks much more like Atom One Dark).