### PR TITLE
Improve C++ highlighting

### DIFF
--- a/themes/Atomize-color-theme.json
+++ b/themes/Atomize-color-theme.json
@@ -897,6 +897,13 @@
       }
     },
     {
+      "name": "C++ Properties",
+      "scope": ["variable.other.property"],
+      "settings": {
+        "foreground": "#BE5046"
+      }
+    },
+    {
       "name": "Inserted",
       "scope": ["markup.inserted"],
       "settings": {

--- a/themes/Atomize-color-theme.json
+++ b/themes/Atomize-color-theme.json
@@ -898,13 +898,6 @@
       }
     },
     {
-      "name": "C++ Properties",
-      "scope": ["variable.other.property"],
-      "settings": {
-        "foreground": "#BE5046"
-      }
-    },
-    {
       "name": "Inserted",
       "scope": ["markup.inserted"],
       "settings": {

--- a/themes/Atomize-color-theme.json
+++ b/themes/Atomize-color-theme.json
@@ -885,6 +885,18 @@
       }
     },
     {
+      "name": "C++ Namespaces",
+      "scope": [
+        "entity.name.scope-resolution.parameter.cpp",
+        "entity.name.scope-resolution.cpp",
+        "entity.name.scope-resolution.function.call.cpp",
+        "entity.name.namespace"
+      ],
+      "settings": {
+        "foreground": "#E5C07B"
+      }
+    },
+    {
       "name": "Inserted",
       "scope": ["markup.inserted"],
       "settings": {

--- a/themes/Atomize-color-theme.json
+++ b/themes/Atomize-color-theme.json
@@ -444,7 +444,7 @@
       }
     },
     {
-      "name": "Class, Types",
+      "name": "Class, Types, Scopes",
       "scope": [
         "support.type",
         "support.class",
@@ -455,7 +455,12 @@
         "support.type.sys-types",
         "entity.other.inherited-class",
         "entity.name.type.class",
-        "entity.name.type"
+        "entity.name.type",
+        "entity.name.namespace",
+        "entity.name.scope-resolution.parameter.cpp",
+        "entity.name.scope-resolution.cpp",
+        "entity.name.scope-resolution.function.call.cpp",
+        "entity.name.scope-resolution.template.call.cpp"
       ],
       "settings": {
         "foreground": "#E5C07B"
@@ -882,19 +887,6 @@
       ],
       "settings": {
         "foreground": "#C678DD"
-      }
-    },
-    {
-      "name": "C++ Namespaces",
-      "scope": [
-        "entity.name.scope-resolution.parameter.cpp",
-        "entity.name.scope-resolution.cpp",
-        "entity.name.scope-resolution.function.call.cpp",
-        "entity.name.scope-resolution.template.call.cpp",
-        "entity.name.namespace"
-      ],
-      "settings": {
-        "foreground": "#E5C07B"
       }
     },
     {

--- a/themes/Atomize-color-theme.json
+++ b/themes/Atomize-color-theme.json
@@ -890,6 +890,7 @@
         "entity.name.scope-resolution.parameter.cpp",
         "entity.name.scope-resolution.cpp",
         "entity.name.scope-resolution.function.call.cpp",
+        "entity.name.scope-resolution.template.call.cpp",
         "entity.name.namespace"
       ],
       "settings": {

--- a/themes/Atomize-color-theme.json
+++ b/themes/Atomize-color-theme.json
@@ -456,11 +456,7 @@
         "entity.other.inherited-class",
         "entity.name.type.class",
         "entity.name.type",
-        "entity.name.namespace",
-        "entity.name.scope-resolution.parameter.cpp",
-        "entity.name.scope-resolution.cpp",
-        "entity.name.scope-resolution.function.call.cpp",
-        "entity.name.scope-resolution.template.call.cpp"
+        "entity.name.namespace"
       ],
       "settings": {
         "foreground": "#E5C07B"
@@ -887,6 +883,18 @@
       ],
       "settings": {
         "foreground": "#C678DD"
+      }
+    },
+    {
+      "name": "C++ Scopes",
+      "scope": [
+        "entity.name.scope-resolution.parameter.cpp",
+        "entity.name.scope-resolution.cpp",
+        "entity.name.scope-resolution.function.call.cpp",
+        "entity.name.scope-resolution.template.call.cpp"
+      ],
+      "settings": {
+        "foreground": "#E5C07B"
       }
     },
     {


### PR DESCRIPTION
**Namespaces**

Regular highlighting:

```
entity.name.scope-resolution.parameter.cpp
entity.name.scope-resolution.cpp
entity.name.scope-resolution.function.call.cpp
entity.name.scope-resolution.template.call.cpp
```

Semantic:

```
entity.name.namespace
```

Tested, works for me as expected, closes #18.