### PR TITLE
Mark enums as constants

### DIFF
--- a/themes/Atomize-color-theme.json
+++ b/themes/Atomize-color-theme.json
@@ -335,7 +335,8 @@
       "scope": [
         "constant.other",
         "variable.other.constant",
-        "variable.other.constant.property"
+        "variable.other.constant.property",
+        "variable.other.enummember"
       ],
       "settings": {
         "foreground": "#D19A66"


### PR DESCRIPTION
Enumerations are, basically, numbered constants. At the moment they have the same color as the variables, which is not very good.