### PR TITLE
Correct the scopes for CSS properties

### DIFF
--- a/demo/css.css
+++ b/demo/css.css
@@ -35,6 +35,7 @@ button:disabled {
 #header {
   animation-duration: 3s;
   animation-name: slidein;
+  padding-inline: 8px;
   --some-color: #282c34;
 }
 

--- a/themes/Atomize-color-theme.json
+++ b/themes/Atomize-color-theme.json
@@ -483,7 +483,7 @@
       "scope": [
         "support.type.map.key.scss",
         "entity.other.keyframe-offset.css",
-        "support.type.property-name.css",
+        "meta.property-name.css",
         "entity.other.attribute-name.scss",
         "support.type.property-name.media.css"
       ],


### PR DESCRIPTION
`meta.property-name.css` appears on all CSS properties, `support.type.property-name.css` doesn't seem to be the case.

![Screenshot_20220305_185636](https://user-images.githubusercontent.com/20620901/156881949-f406c53d-23c2-446c-a06d-ea060edcbbc4.png)
