### PR TITLE
Update Atomize-color-theme.json

### DIFF
--- a/themes/Atomize-color-theme.json
+++ b/themes/Atomize-color-theme.json
@@ -393,7 +393,7 @@
       "name": "Object key",
       "scope": ["meta.object-literal.key"],
       "settings": {
-        "foreground": "#98C379"
+        "foreground": "#ABB2BF"
       }
     },
 


### PR DESCRIPTION
I just find it odd that the property keys are the same color as string literals:
<img width="187" alt="Skjermbilde 2025-05-10 kl  08 38 01" src="https://github.com/user-attachments/assets/575829b5-41c6-4117-b767-4ba5bbea1027" />

Does this look better?
<img width="171" alt="Skjermbilde 2025-05-10 kl  08 38 44" src="https://github.com/user-attachments/assets/e352437a-73f5-422e-aef7-77a68f85e6cf" />
